### PR TITLE
Release SSR-safe runtime deps

### DIFF
--- a/.changeset/silent-timers-change.md
+++ b/.changeset/silent-timers-change.md
@@ -1,0 +1,5 @@
+---
+"rhf-mantine": patch
+---
+
+Remove `@hookform/devtools` from the runtime dependency graph to avoid SSR bundling failures in Next.js/Turbopack.


### PR DESCRIPTION
Adds a patch changeset for the unreleased SSR fix on main.\n\nMain already removes `@hookform/devtools` from runtime deps, which removes `react-simple-animate` from consumer SSR bundles and avoids Next/Turbopack dynamic require failures.\n\nVerified:\n- `pnpm build` passes\n- `rg '@hookform/devtools|react-simple-animate|DevTool' package.json pnpm-lock.yaml src dist` returns no matches\n\nNote: `pnpm knip` still reports existing unrelated issues: unused `prettier`, unlisted `only-allow`.